### PR TITLE
Changed axis name and moved default to ROUND=100

### DIFF
--- a/_sources/Wavefont.designspace
+++ b/_sources/Wavefont.designspace
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
     <axes>
-        <axis default="0" minimum="0" maximum="100" name="Roundness" tag="ROND"/>
-        <axis default="-100" minimum="-100" maximum="100" name="Y Alignment" tag="YELA">
+        <axis default="100" minimum="0" maximum="100" name="Roundness" tag="ROND"/>
+        <axis default="-100" minimum="-100" maximum="100" name="Vertical Element Alignment" tag="YELA">
             <map input="-100" output="0"/>
             <map input="100" output="1"/>
         </axis>

--- a/sources/wavefont.designspace
+++ b/sources/wavefont.designspace
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
     <axes>
-        <axis default="0" minimum="0" maximum="100" name="Roundness" tag="ROND"/>
-        <axis default="-100" minimum="-100" maximum="100" name="Y Alignment" tag="YELA">
+        <axis default="100" minimum="0" maximum="100" name="Roundness" tag="ROND"/>
+        <axis default="-100" minimum="-100" maximum="100" name="Vertical Element Alignment" tag="YELA">
             <map input="-100" output="0"/>
             <map input="100" output="1"/>
         </axis>


### PR DESCRIPTION
Hi @dy 
The full name will be (if everything goes according to plan) "Vertical Element Alignment" and since the instances in the FVAR are having ROND=100, I thought it would be better to have that for the zero origin too, the build will still work?

I didn't re-built the font. 