### PR TITLE
Update config.yaml

### DIFF
--- a/_sources/config.yaml
+++ b/_sources/config.yaml
@@ -31,6 +31,8 @@ stat:
       value: 300
     - name: Regular
       value: 400
+      linkedValue: 700
+      flags: 2
     - name: Medium
       value: 500
     - name: SemiBold
@@ -41,3 +43,6 @@ stat:
       value: 800
     - name: Black
       value: 900
+    - name: ExtraBlack
+      value: 1000
+      


### PR DESCRIPTION
retrying after my fail in #59 

> We could map the value 20 to 1, so we can have "Hairline" at 1, we unofficially accept it in the STAT table. Otherwise it's okay. But we can't distribute a font with the default under 100, it would cause rendering issues in some OS. We would need to keep it at as before.